### PR TITLE
aligned the instamart section for small screen sizes

### DIFF
--- a/src/components/MainSection4.css
+++ b/src/components/MainSection4.css
@@ -1,10 +1,14 @@
 /* MainSection4.css */
 
 .section-4 {
-  width: 100%;
+  /* width: 100%;
   max-width: 1240px;
   margin: 0 auto;
-  padding: 20px;
+  padding: 20px; */
+  display: flex;
+  justify-content: space-around;
+  height: 400px;
+  min-width: 1240px;
 }
 
 .container {
@@ -32,6 +36,8 @@
   gap: 15px;
   overflow-x: auto;
   scroll-behavior: smooth;
+  justify-content: center;
+  align-items: center;
 }
 
 .menu-instamart img {
@@ -75,6 +81,7 @@
 
   .menu-instamart {
     gap: 10px;
+    justify-content: center;
   }
 
   .menu-instamart img {


### PR DESCRIPTION
### Instamart Alignment 
Fix #2
- Earlier the Instamart section was not aligned for small screen sizes.
![image](https://github.com/user-attachments/assets/7608384f-41b3-427a-9055-cbdc82363705)
- The current page 
![image](https://github.com/user-attachments/assets/bf7c4009-1e85-46af-89a9-611e91ccbdcb)
@Sanskriti65 kindly assign the points and merge the pull request.
