### PR TITLE
now mobile navbar work on less than max width:768

### DIFF
--- a/src/components/Navbar.css
+++ b/src/components/Navbar.css
@@ -23,7 +23,6 @@ body {
   /* Bottom Navbar Styles */
   .bottom-navbar {
     display: flex;
-    bottom: 20px;
     justify-content: space-around;
     align-items: center;
     padding: 10px 0;
@@ -69,9 +68,9 @@ body {
   }
   
   /* Desktop View (Optional) */
-  @media (min-width: 1024px) {
+  @media (min-width: 769px) {
     .bottom-navbar {
-      justify-content: space-evenly;
+      display:none ;
     }
   
     .nav-item {


### PR DESCRIPTION

### Description:

This PR addresses the issue where the mobile navbar needs to be displayed only for mobile users and hidden for desktop users. The implementation ensures a responsive and device-specific navigation experience.

**Changes Implemented:**

Device Detection:

Used a combination of screen width detection via CSS media queries to identify mobile devices.


**Conditional Rendering:**

Mobile navbar is displayed only when the screen width is below the defined breakpoint (e.g., 768px).

For larger screen sizes (desktop/tablet), the mobile navbar is hidden.



Code Highlights:

CSS Media Query:

@media (max-width: 768px) {
  .mobile-navbar {
    display: flex;
  }
}

@media (min-width: 769px) {
  .mobile-navbar {
    display: none;
  }
}


**Testing:**

Verified that the mobile navbar appears correctly on devices with a screen width below the defined breakpoint.

Confirmed that the navbar remains hidden on larger devices such as tablets and desktops.

**Tested on:**

Chrome, Firefox, and Safari browsers.

iOS and Android devices.



**Impact:**

Improves the user experience by showing a clean, mobile-optimized navigation for mobile users while keeping the desktop interface uncluttered.


**Additional Notes:**

Breakpoint value can be adjusted based on the design system (currently set at 768px).

**size less than 768**

![Screenshot 2025-01-07 235509](https://github.com/user-attachments/assets/716479df-f376-4787-853c-0f173b99ed60)

**size greater than 768**

![Screenshot 2025-01-07 235529](https://github.com/user-attachments/assets/dde684ba-134e-4197-bdee-01a19677af57)



