### PR TITLE
Resolve Search Bar Overlap with Cards Section on Main Page

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -162,6 +162,7 @@ a{
     text-align: center;
     padding: 5px;
     gap: 10px;
+    margin-bottom: 20px;
 }
 .input-location input{
     height: 54px;
@@ -182,7 +183,7 @@ a{
     padding: 10px;
 }
 .menu-boxes{
-    margin-top: -250px;
+    margin-top:-80px;
 }
 .boxes{
     display: -webkit-box;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ensure a seamless user interface by addressing the overlap issue between the search bar and the cards section on the main page. Enhance user experience by maintaining proper spacing and alignment for a visually appealing design.


issue no 40

## Screenshots (if appropriate):
<img width="941" alt="image" src="https://github.com/user-attachments/assets/421be43b-9076-45c6-a22c-937ea6857953" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [X ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] My code follows the code style of this project.

