### PR TITLE
Added phone number input validation in Signup/login

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -3,10 +3,14 @@ import React, { useState } from "react";
 import "./Login.css";
 import { Link } from "react-router-dom";
 
+const Login = ({ toggleSidebar }) => {
+  const [mobile, setMobile] = useState("");
+  const [error, setError] = useState("");
 
-const Login = ({toggleSidebar }) => {
-  const [mobile, setMobile] = useState(""); // Changed to 'mobile'
-  const [error, setError] = useState(""); // Error state for validation
+  const handleMobileChange = (e) => {
+    const value = e.target.value.replace(/\D/g, '').slice(0, 10);
+    setMobile(value);
+  };
 
   const handleLogin = (e) => {
     e.preventDefault();
@@ -19,7 +23,6 @@ const Login = ({toggleSidebar }) => {
     console.log("Logged in with mobile:", mobile);
     localStorage.setItem("isAuthenticated", "true");
     toggleSidebar();
-
   };
 
   const handleCancel = () => {
@@ -38,8 +41,20 @@ const Login = ({toggleSidebar }) => {
             className="input-field"
             maxLength="10"
             value={mobile}
-            onChange={(e) => setMobile(e.target.value)}
+            onChange={handleMobileChange}
+            onKeyDown={(e) => {
+              if (!/[0-9]|Backspace|Delete|ArrowLeft|ArrowRight|Tab/.test(e.key)) {
+                e.preventDefault();
+              }
+            }}
+            onPaste={(e) => {
+              const paste = (e.clipboardData || window.clipboardData).getData('text');
+              if (!/^\d+$/.test(paste)) {
+                e.preventDefault();
+              }
+            }}
             autoComplete="off"
+            inputMode="numeric"
             required
           />
           <label htmlFor="mobile" className="input-label">
@@ -54,8 +69,6 @@ const Login = ({toggleSidebar }) => {
             Login
           </button>
         </div>
-
-        
 
         <div className="terms-conditions">
           By clicking on Login, I accept the{" "}

--- a/src/components/Signup.js
+++ b/src/components/Signup.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "./Signup.css";
 import { useNavigate } from "react-router-dom";
 
-const Signup = ({toggleSidebar}) => {
+const Signup = ({ toggleSidebar }) => {
   const [formData, setFormData] = useState({
     mobile: "",
     name: "",
@@ -10,10 +10,35 @@ const Signup = ({toggleSidebar}) => {
   });
 
   const [error, setError] = useState("");
-  const navigate=useNavigate();
+  const navigate = useNavigate();
 
   const handleChange = (e) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    
+    if (name === "mobile") {
+      // Remove all non-digit characters
+      const digitsOnly = value.replace(/\D/g, '');
+      setFormData({ ...formData, [name]: digitsOnly });
+    } else {
+      setFormData({ ...formData, [name]: value });
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.target.name === "mobile") {
+      // Allow: backspace, delete, tab, escape, enter
+      if ([8, 9, 27, 13, 46].includes(e.keyCode) ||
+          // Allow: Ctrl+A, Ctrl+C, Ctrl+V, Ctrl+X
+          (e.ctrlKey && [65, 67, 86, 88].includes(e.keyCode)) ||
+          // Allow: home, end, left, right
+          (e.keyCode >= 35 && e.keyCode <= 39)) {
+        return;
+      }
+      // Prevent if not a number
+      if ((e.shiftKey || (e.keyCode < 48 || e.keyCode > 57)) && (e.keyCode < 96 || e.keyCode > 105)) {
+        e.preventDefault();
+      }
+    }
   };
 
   const handleSignup = (e) => {
@@ -54,7 +79,9 @@ const Signup = ({toggleSidebar}) => {
             maxLength="10"
             value={formData.mobile}
             onChange={handleChange}
+            onKeyDown={handleKeyDown}
             autoComplete="off"
+            inputMode="numeric"
             required
           />
           <label htmlFor="mobile" className="input-label">


### PR DESCRIPTION
Enforce Numeric-Only Input for Phone Number Field

fixes #91 

## Description

Implemented strict numeric-only input validation for phone number fields in both Login and Signup components
Added handlers to prevent non-numeric keyboard input (onKeyDown)
Added paste validation to filter non-numeric content (onPaste)
Maintained existing 10-digit validation while improving input handling
Added inputMode="numeric" for better mobile keyboard experience
Ensured consistent behavior between Login and Signup component

## Motivation and Context

Previously, users could enter alphabetic characters in phone number fields
The input would accept but then fail validation, creating poor UX
This change prevents invalid input at the source rather than showing errors after submission


## Screenshots :

![Screenshot 2025-05-01 120907](https://github.com/user-attachments/assets/b2a3b98e-6746-4413-9e4b-d989ad30f6fe)
